### PR TITLE
add an int() to make the i/4 be a interger rather than a float

### DIFF
--- a/aes.py
+++ b/aes.py
@@ -81,7 +81,7 @@ def text2matrix(text):
         if i % 4 == 0:
             matrix.append([byte])
         else:
-            matrix[i / 4].append(byte)
+            matrix[int(i / 4)].append(byte)
     return matrix
 
 
@@ -106,7 +106,7 @@ class AES:
             if i % 4 == 0:
                 byte = self.round_keys[i - 4][0]        \
                      ^ Sbox[self.round_keys[i - 1][1]]  \
-                     ^ Rcon[i / 4]
+                     ^ Rcon[int(i / 4)]
                 self.round_keys[i].append(byte)
 
                 for j in range(1, 4):


### PR DESCRIPTION
In python3, a integer divide another interger will generate a float , in "aes.py"  ,   line 58, line 83, if we don not add an int to it ,there will be a  TypeError: list indices must be integers or slices, not float